### PR TITLE
Change to get working from Tribblix ISO

### DIFF
--- a/install-with-zap.sh
+++ b/install-with-zap.sh
@@ -16,7 +16,7 @@ case $# in
 	;;
 esac
 
-INSTZAP=/usr/lib/zap/zap
+INSTZAP=/usr/lib/zap/install-pkg
 if [ ! -x ${INSTZAP} ]; then
     echo "ERROR: unable to find zap"
     exit 1

--- a/mvi.sh
+++ b/mvi.sh
@@ -11,7 +11,7 @@ ISO_NAME=/tmp/mvi.iso
 #
 # Tribblix version for illumos pkgs
 #
-DISTVER=17
+DISTVER=18
 ILVER=0.${DISTVER}
 
 #

--- a/mvi.sh
+++ b/mvi.sh
@@ -6,7 +6,7 @@
 #
 # where the iso should end up
 #
-ISO_NAME=/var/tmp/mvi.iso
+ISO_NAME=/tmp/mvi.iso
 
 #
 # Tribblix version for illumos pkgs
@@ -339,7 +339,7 @@ mkfile ${MRSIZE} /tmp/${MRSIZE}
 #
 # gzip doesn't like the sticky bit
 #
-chmod o-t /tmp/${MRSIZE}
+chmod -t /tmp/${MRSIZE}
 LOFIDEV=`lofiadm -a /tmp/${MRSIZE}`
 LOFINUM=`echo $LOFIDEV|awk -F/ '{print $NF}'`
 echo "y" | env NOINUSE_CHECK=1 newfs -o space -m 0 -i $NBPI /dev/rlofi/$LOFINUM
@@ -362,10 +362,12 @@ rm -fr ${BFS}/dev/zcons/*
 cd /
 DF=/usr/bin/df
 if [ -x /usr/gnu/bin/df ]; then
-    DF=/usr/gnu/bin/df
+  DF=/usr/gnu/bin/df
+  $DF -h $BFS
+  $DF -i $BFS
+else
+  $DF -h $BFS
 fi
-$DF -h $BFS
-$DF -i $BFS
 
 #
 # unmount, then compress the block device and copy it back

--- a/mvix.sh
+++ b/mvix.sh
@@ -11,7 +11,7 @@ ISO_NAME=/var/tmp/mvi.iso
 #
 # Tribblix version for illumos pkgs
 #
-DISTVER=17
+DISTVER=18
 ILVER=0.${DISTVER}
 
 #

--- a/node.pkgs
+++ b/node.pkgs
@@ -1,2 +1,2 @@
-TRIBgcc4runtime.4.8.3.0
-TRIBv-node-v4.4.2.0.0
+TRIBgcc4runtime.4.8.5.0
+TRIBv-node-v4.4.6.1.0


### PR DESCRIPTION
Hi, with install-from-zap working well I am looking to get mvi script working directly from installer ISO to avoid the step of creating a Tribblix VM. What I've changed:

- Final location of ISO file to /tmp
- chmod sticky bit compatible with ISO chmod
- df -i doesn't works in non-gnu df command